### PR TITLE
Add an example of the KodeinDI library 

### DIFF
--- a/kotlin-jvm/build.gradle.kts
+++ b/kotlin-jvm/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
     implementation(Ktor.client.okHttp)
     implementation(Ktor.client.serialization)
 
+    implementation("org.kodein.di:kodein-di:_")
+
     implementation(Square.retrofit2.retrofit)
     implementation(Square.retrofit2.converter.moshi)
     implementation(JakeWharton.retrofit2.converter.kotlinxSerialization)

--- a/kotlin-jvm/src/main/kotlin/playground/KodeinDI.kt
+++ b/kotlin-jvm/src/main/kotlin/playground/KodeinDI.kt
@@ -1,0 +1,89 @@
+@file:Suppress("PackageDirectoryMismatch")
+
+package playground.kodein.di
+
+import org.kodein.di.*
+import playground.shouldBe
+
+/**
+ * Kodein DI: painless Kotlin dependency injection
+ *
+ * - [Website](kodein.org/di/)
+ * - [Github](https://github.com/Kodein-Framework/Kodein-DI)
+ * - [CHANGELOG](https://github.com/Kodein-Framework/Kodein-DI/blob/master/CHANGELOG.md)
+ */
+fun main() {
+    println("# Kotlin/org.kodein.di : Kotlin multiplatform / painless dependency injection")
+
+    // A dependency container that provides a UserRepository for testing and a "real" one.
+    val deps = DI {
+        bind<UserRepository>(tag = "test") with singleton { MockedUserStore() }
+        bind<UserRepository>() with singleton { InMemoryUserStore() }
+    }
+
+    val testApp by deps.newInstance { Application(instance(tag = "test")) }
+    val realApp by deps.newInstance { Application(instance()) }
+
+    val user = User(1)
+
+    testApp.addUser(user)
+    // In the test app, we want always the same user.
+    testApp.getUser(1) shouldBe User(123)
+
+    realApp.addUser(user)
+    // IN the real app, we want the users we have previously stored.
+    realApp.getUser(1) shouldBe user
+}
+
+/**
+ * Abstraction of an application that can get and add users given a  UserRepository.
+ */
+internal class Application(private val userRepository: UserRepository) {
+    fun getUser(id: Int): User? {
+        return userRepository.userById(id)
+    }
+
+    fun addUser(user: User) {
+        userRepository.addUser(user)
+    }
+}
+
+/**
+ * An interface that defines a user repository.
+ */
+interface UserRepository {
+    fun addUser(user: User)
+    fun userById(id: Int): User?
+}
+
+/**
+ * A barebones user model.
+ */
+data class User(val id: Int)
+
+/**
+ * User repository that stores data in memory.
+ */
+internal class InMemoryUserStore : UserRepository {
+    private val users: HashMap<Int, User> = HashMap()
+
+    override fun addUser(user: User) {
+        users[user.id] = user
+    }
+
+    override fun userById(id: Int): User? {
+        return users[id]
+    }
+}
+
+/**
+ * User repository that always returns a user with id 123.
+ */
+internal class MockedUserStore : UserRepository {
+    override fun addUser(user: User) {
+    }
+
+    override fun userById(id: Int): User? {
+        return User(123)
+    }
+}

--- a/kotlin-jvm/versions.properties
+++ b/kotlin-jvm/versions.properties
@@ -42,3 +42,9 @@ version.org.spekframework.spek2..spek-runner-junit5=2.0.13
 version.org.spekframework.spek2..spek-runtime-jvm=2.0.13
 
 version.retrofit2=2.9.0
+
+version.io.mockk..mockk=1.10.2
+
+version.org.junit.jupiter..junit-jupiter=5.7.0
+
+version.org.kodein.di..kodein-di=7.1.0


### PR DESCRIPTION
The example is an application that can add and get users to a datastore represented by a `UserRepository`.

The idea is to show that in tests of this application we could inject a mocked `UserRepository`, while in any other case we could inject an "real" store (in-memory store, in this case).

I added comments in the code to make it more clear to readers as there are plenty of things there: classes, dataclasses, interfaces, etc.

This fixes #11 